### PR TITLE
"Back to calendar" link in event page when opened in new tab/window

### DIFF
--- a/src/client/calendar/events/event-details/EventDetails.jsx
+++ b/src/client/calendar/events/event-details/EventDetails.jsx
@@ -104,6 +104,8 @@ class EventDetails extends Component {
       promoterInfo,
     } = this.props.event
 
+    const { calendar } = this.props
+
     // TODO: migrate old events to have flyer section and not just "flyerUrl" property
     const { movedToEvent } = this.props
 
@@ -312,6 +314,7 @@ class EventDetails extends Component {
         : (
           // eslint-disable-next-line
           <div className='EventDetails-container'>
+            <Link className="back-to-calendar" to={`/calendars/${calendar.slug}?past=visible`}>Back to {calendar.name}</Link>
             {eventDetailsComponent}
           </div>
         )
@@ -321,6 +324,7 @@ class EventDetails extends Component {
 
 EventDetails.propTypes = {
   event: PropTypes.object.isRequired,
+  calendar: PropTypes.object,
   // if event status is "Moved" this would contain event it's moved to
   movedToEvent: PropTypes.object,
 }
@@ -328,7 +332,7 @@ EventDetails.propTypes = {
 export { EventDetails }
 
 import { connect } from 'react-redux'
-import { getEvent } from 'shared/reducers/reducer.js'
+import { getEvent, getCalendar } from 'shared/reducers/reducer.js'
 import { replaceRoutedModal } from 'shared/actions/actions.js'
 
 export default connect(
@@ -337,13 +341,14 @@ export default connect(
     // calendar: getCalendar()
 
     const event = getEvent(state, ownProps.params.eventId)
+    const calendar = getCalendar(state, {calendarId: event.calendarId})
     let movedToEvent
 
     if (event.status === Statuses.moved && event.movedToEventId) {
       movedToEvent = getEvent(state, event.movedToEventId)
     }
 
-    return { event, movedToEvent }
+    return { event, movedToEvent, calendar }
   },
   (dispatch, ownProps) => ({
     replaceRoutedModal: (path) => dispatch(replaceRoutedModal({path, hasPadding: false}))

--- a/src/client/calendar/events/event-details/EventDetails.scss
+++ b/src/client/calendar/events/event-details/EventDetails.scss
@@ -16,6 +16,13 @@
     width: 100%;
     max-width: 100%;
   }
+
+  .back-to-calendar {
+    position: absolute;
+    z-index: 1;
+    left: 4rem;
+    top: 1rem;
+  }
 }
 
 .EventDetails {

--- a/src/shared/reducers/reducer.js
+++ b/src/shared/reducers/reducer.js
@@ -26,6 +26,8 @@ const toByIdMap = objects => objects.reduce((map, x) => {
   return map
 }, {})
 
+const setEventsCalendarId = calendarId => event => Object.assign({}, event, {calendarId})
+
 const toArrayOfIds = objects => objects.map(x => x.id)
 
 const initialState = {
@@ -60,16 +62,17 @@ const initialState = {
   },
 
   events: toByIdMap(
-    norcalMtb2016Events
-    .concat(ncnca2016Events)
-    .concat(ncnca2017Events)
-    .concat(usac2017Events)
+    norcalMtb2016Events.map(setEventsCalendarId('cal-norcal-mtb-2016'))
+    .concat(ncnca2016Events.map(setEventsCalendarId('cal-ncnca-2016')))
+    .concat(ncnca2017Events.map(setEventsCalendarId('cal-ncnca-2017')))
+    .concat(usac2017Events.map(setEventsCalendarId('cal-usac-2017')))
   ),
 
   //calenars map by id
   calendars: {
     ['cal-norcal-mtb-2016']: {
       id: 'cal-norcal-mtb-2016',
+      slug: 'norcal-mtb',
       year: 2016,
       name: '2016 NorCal MTB Calendar',
       highlight: {
@@ -82,6 +85,7 @@ const initialState = {
     },
     ['cal-ncnca-2017-draft']: {
       id: 'cal-ncnca-2017-draft',
+      slug: 'ncnca-2017',
       year: 2017,
       name: '2017 NCNCA Calendar',
       // highlight: {
@@ -97,6 +101,7 @@ const initialState = {
     },
     ['cal-ncnca-2018-draft']: {
       id: 'cal-ncnca-2018-draft',
+      slug: 'ncnca-2017',
       year: 2018,
       name: '2018 NCNCA Calendar',
       // highlight: {
@@ -113,6 +118,7 @@ const initialState = {
     },
     ['cal-ncnca-2016']: {
       id: 'cal-ncnca-2016',
+      slug: 'ncnca-2016',
       year: 2016,
       name: '2016 NCNCA Calendar',
       // highlight: {
@@ -127,6 +133,7 @@ const initialState = {
     },
     ['cal-ncnca-2017']: {
       id: 'cal-ncnca-2017',
+      slug: 'ncnca-2017',
       year: 2017,
       name: '2017 NCNCA Calendar',
       // highlight: {
@@ -141,6 +148,7 @@ const initialState = {
     },
     ['cal-usac-2017']: {
       id: 'cal-usac-2017',
+      slug: 'usac-2017',
       year: 2017,
       name: '2017 USA Cycling Calendar',
       // highlight: {


### PR DESCRIPTION
1. Now calendar's id is added to an event, so it's possible to find calendar by an event
2. Calendars objects have "slug" field to simplify URLs creation